### PR TITLE
Add Yolov5 model training and inference files

### DIFF
--- a/raid-ai/main.py
+++ b/raid-ai/main.py
@@ -1,0 +1,24 @@
+## RaiD Yolov5 inference script
+from glob import glob
+import torch
+
+
+def predict(modelpath: str, test_images: list):
+    """
+    Run inference with the yolov5 model
+    """
+    model = torch.hub.load("ultralytics/yolov5", "custom", path=modelpath, force_reload=True)
+    # Inference
+    results = model(test_images)
+    results.print() # prints the defects on each image
+    results.save() # Store image with bboxes highlighting defects
+
+
+if __name__=="__main__":
+    # Load trained Model weights
+    MODEL_PATH = "/content/drive/MyDrive/final_year_project/raid/best.pt" # do away with static path naming
+    # Test image batch
+    IMAGES = glob("/content/drive/MyDrive/final_year_project/raid/test_images/*.jpg")
+
+    predict(MODEL_PATH, IMAGES)
+    

--- a/raid-ai/read_dicom.py
+++ b/raid-ai/read_dicom.py
@@ -1,0 +1,55 @@
+## Load and Reading dicom format radiographs
+
+import os
+from glob import glob
+import tensorflow as tf
+import tensorflow_io as tfio
+
+def read_dicom(path):
+    """Load and read dicom type images."""
+    image_bytes = tf.io.read_file(path)
+    image = tfio.image.decode_dicom_image(
+        image_bytes, 
+        dtype = tf.uint16
+    )
+    
+    image = tf.squeeze(image, axis = 0)
+    
+    image = tf.image.resize(
+        image, 
+        (500, 500), 
+        preserve_aspect_ratio = True
+    )
+    
+    image = image - tf.reduce_min(image)
+    image = image / tf.reduce_max(image)
+    image = tf.cast(image * 255, tf.uint8)
+    
+    return image
+
+
+def convert_dicom_to_jpg(image_path, save_dir):
+    """
+    Converts a .dicom image to .jpg for easier storage and loading.
+    The converted image(s) are saved in the save_dir directory.
+    """
+    for dicom_file in image_path:
+        image_ = read_dicom(dicom_file)
+        
+        image = tf.io.encode_jpeg(
+        image_, 
+        quality = 100, 
+        format = 'grayscale'
+    )
+    
+        name = dicom_file.replace(".dicom", ".jpg")
+        tf.io.write_file(os.path.join(save_dir, name), image) # saves the converted images
+
+if __name__=="__main__":
+
+    BASE_PATH = "/content/drive/MyDrive/final_year_project/raid/dicom_images/" # location of converted jpg images
+    DICOM_IMG_PATHS = glob("/content/drive/MyDrive/final_year_project/raid/dicom_images/*.dicom")
+
+    convert_dicom_to_jpg(DICOM_IMG_PATHS, BASE_PATH)
+
+    

--- a/raid-ai/requirements.txt
+++ b/raid-ai/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow==2.4.1
+tensorflow-io==0.23.1

--- a/raid-ai/yolo_inference.ipynb
+++ b/raid-ai/yolo_inference.ipynb
@@ -1,0 +1,164 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "yolo_inference.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NfL0jSTUNuTS",
+        "outputId": "205a6047-a625-4f28-ebcd-1eee5979633c"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Mounted at /content/drive\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "IABRdxMmMlzs",
+        "outputId": "894c3412-d16d-4191-9d69-6a1bc62fc421"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading: \"https://github.com/ultralytics/yolov5/archive/master.zip\" to /root/.cache/torch/hub/master.zip\n",
+            "YOLOv5 🚀 2021-12-19 torch 1.10.0+cu111 CUDA:0 (Tesla K80, 11441MiB)\n",
+            "\n",
+            "Fusing layers... \n",
+            "Model Summary: 484 layers, 88478091 parameters, 0 gradients\n",
+            "Adding AutoShape... \n",
+            "image 1/3: 3028x2517 1 Aortic enlargement, 1 Nodule/Mass\n",
+            "image 2/3: 2584x2345 (no detections)\n",
+            "image 3/3: 3000x3000 1 Aortic enlargement, 1 Cardiomegaly\n",
+            "Speed: 150.4ms pre-process, 235.3ms inference, 1.5ms NMS per image at shape (3, 3, 640, 640)\n",
+            "Saved 3 images to \u001b[1mruns/detect/exp2\u001b[0m\n"
+          ]
+        }
+      ],
+      "source": [
+        "!wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip\n",
+        "!unzip -o ngrok-stable-linux-amd64.zip\n",
+        "\n",
+        "from IPython import get_ipython\n",
+        "\n",
+        "\n",
+        "!python /content/drive/MyDrive/final_year_project/raid/main.py"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "metadata": {
+        "id": "9fdj3CfKOFdC"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Test load .dicom images\n",
+        "!pip install tensorflow-io"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LsLemTmkQ1SL",
+        "outputId": "967d0b3f-82d2-4194-9093-86fdeaffe391"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting tensorflow-io\n",
+            "  Downloading tensorflow_io-0.23.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (23.1 MB)\n",
+            "\u001b[K     |████████████████████████████████| 23.1 MB 43.6 MB/s \n",
+            "\u001b[?25hCollecting tensorflow-io-gcs-filesystem==0.23.1\n",
+            "  Downloading tensorflow_io_gcs_filesystem-0.23.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (2.1 MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.1 MB 38.5 MB/s \n",
+            "\u001b[?25hInstalling collected packages: tensorflow-io-gcs-filesystem, tensorflow-io\n",
+            "  Attempting uninstall: tensorflow-io-gcs-filesystem\n",
+            "    Found existing installation: tensorflow-io-gcs-filesystem 0.22.0\n",
+            "    Uninstalling tensorflow-io-gcs-filesystem-0.22.0:\n",
+            "      Successfully uninstalled tensorflow-io-gcs-filesystem-0.22.0\n",
+            "Successfully installed tensorflow-io-0.23.1 tensorflow-io-gcs-filesystem-0.23.1\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!python /content/drive/MyDrive/final_year_project/raid/read_dicom.py"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eAxOiwHSQ3_I",
+        "outputId": "ac1850e2-65c5-4a0b-987f-d37ef047e4ad"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "2021-12-19 11:07:38.173048: W tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc:39] Overriding allow_growth setting because the TF_FORCE_GPU_ALLOW_GROWTH environment variable is set. Original config value was 0.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "metadata": {
+        "id": "4HmTxkAsRE6v"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Added model training notebook along with all scripts necessary to run inference/get predictions.
Additionally a script to read .dicom images and convert them to .jpg images for efficient storage and quick access is added. The functionality in this script will later be integrated into the backend.

Note:
All data necessary for inference purposes is stored in the shared google drive folder.